### PR TITLE
C99's _Bool and C++ bool are at least 1 byte wide, but can be wider

### DIFF
--- a/blah/rust-layouts-and-abis/index.md
+++ b/blah/rust-layouts-and-abis/index.md
@@ -245,7 +245,7 @@ Here is a table of the ABIs of the core primitives in Rust, which C/C++ types th
 | &mut T         | ptr  | ptr   | integer | T*                | not null                    |
 | Option<&T>     | ptr  | ptr   | integer | T*                | all                         |
 | Option<&mut T> | ptr  | ptr   | integer | T*                | all                         |
-| bool           | 1    | 1     | integer | bool (_Bool)      | 0=false, 1=true             |
+| bool           | ≥1   | ≥1    | integer | bool (_Bool)      | 0=false, 1=true             |
 | char           | 4    | ≤4    | N/A     | N/A               | 0x0-0xD7FF, 0xE000-0x10FFFF |
 | f32            | 4    | ≤4    | float   | float             | all                         |
 | f64            | 8    | ≤8    | float   | double            | all                         |


### PR DESCRIPTION
From [MSVC 2012 docs](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2012/tf4dy80a(v=vs.110)):

> In Visual C++4.2, the Standard C++ header files contained a typedef that equated bool with int. In Visual C++ 5.0 and later, bool is implemented as a built-in type with a size of 1 byte. That means that for Visual C++ 4.2, a call of sizeof(bool) yields 4, while in Visual C++ 5.0 and later, the same call yields 1.

Now, the rust docs mention size 1, because that's the size of `_Bool` on all platforms that Rust currently support, but [this comment](https://github.com/rust-lang/rust/pull/46176#issuecomment-359593446) hints that the intent was for bool to be identical to C's `_Bool` so that it is C FFI safe (it explicitly states that the intent is to prevent having to add a `c_bool` type).